### PR TITLE
Remove automatically created "main" from test documentation

### DIFF
--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -506,8 +506,16 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
             hir::ItemKind::Mod(ref m) => {
                 self.enter_mod(item.owner_id.def_id, m, name, renamed, import_id);
             }
-            hir::ItemKind::Fn(..)
-            | hir::ItemKind::ExternCrate(..)
+            hir::ItemKind::Fn(fn_sig, _, _) => {
+                // Don't show auto created function "main" that is not in the source code (empty span) when documenting tests.
+                if !(self.cx.cache.document_tests
+                    && fn_sig.span.is_empty()
+                    && name.as_str() == "main")
+                {
+                    self.add_to_current_mod(item, renamed, import_id);
+                }
+            }
+            hir::ItemKind::ExternCrate(..)
             | hir::ItemKind::Enum(..)
             | hir::ItemKind::Struct(..)
             | hir::ItemKind::Union(..)


### PR DESCRIPTION
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->